### PR TITLE
Add FastAPI property enrichment example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
-Finding distressed properties and scraping data from public sources, passing data, cleaning data enriching day
+# Property Enrichment Example
+
+This small FastAPI app demonstrates how to enrich a Propwire CSV with data from the Estated API. A minimal Tailwind page lets you upload a CSV and download the enriched result.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Create a `.env` file with your Estated API key:
+   ```bash
+   ESTATED_TOKEN=your_key_here
+   ```
+3. Run the server:
+   ```bash
+   uvicorn app.main:app --reload
+   ```
+
+Navigate to `http://localhost:8000` to upload a file. The service returns a CSV with an extra `avm` column containing the estimated property value. API keys are loaded from environment variables for security.

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,52 @@
+from fastapi import FastAPI, UploadFile, File, HTTPException, Request
+from fastapi.responses import StreamingResponse, HTMLResponse
+from fastapi.templating import Jinja2Templates
+import pandas as pd
+import httpx
+import os
+import io
+
+app = FastAPI()
+templates = Jinja2Templates(directory="app/templates")
+
+ESTATED_TOKEN = os.getenv("ESTATED_TOKEN")
+
+if not ESTATED_TOKEN:
+    raise RuntimeError("ESTATED_TOKEN missing in environment")
+
+async def fetch_estated(session: httpx.AsyncClient, address: str, city: str, state: str, zip_code: str):
+    url = (
+        "https://api.estated.com/v4/property?"
+        f"address={address},{city},{state}&postal_code={zip_code}&token={ESTATED_TOKEN}"
+    )
+    resp = await session.get(url, timeout=10)
+    resp.raise_for_status()
+    return resp.json()
+
+
+@app.get("/", response_class=HTMLResponse)
+async def index(request: Request):
+    return templates.TemplateResponse("index.html", {"request": request})
+
+@app.post("/enrich")
+async def enrich(csv_file: UploadFile = File(...)):
+    try:
+        contents = await csv_file.read()
+        df = pd.read_csv(io.BytesIO(contents))
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=f"Invalid CSV: {e}")
+
+    async with httpx.AsyncClient() as session:
+        results = []
+        for _, row in df.iterrows():
+            try:
+                data = await fetch_estated(session, row['address'], row['city'], row['state'], str(row['zip']))
+                avm = data.get('data', {}).get('valuation', {}).get('value')
+                results.append({**row, 'avm': avm})
+            except Exception:
+                results.append({**row, 'avm': None})
+
+    output = io.StringIO()
+    pd.DataFrame(results).to_csv(output, index=False)
+    output.seek(0)
+    return StreamingResponse(iter([output.getvalue()]), media_type='text/csv')

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <title>Prop Enrich</title>
+</head>
+<body class="min-h-screen bg-gray-100 flex items-center justify-center">
+  <form id="upload-form" class="bg-white p-6 rounded shadow" enctype="multipart/form-data">
+    <h1 class="text-xl mb-4">Upload Propwire CSV</h1>
+    <input type="file" name="csv_file" class="mb-4" accept=".csv" required>
+    <button type="submit" class="px-4 py-2 bg-blue-500 text-white rounded">Enrich</button>
+  </form>
+  <script>
+    const form = document.getElementById('upload-form');
+    form.onsubmit = async (e) => {
+      e.preventDefault();
+      const fd = new FormData(form);
+      const res = await fetch('/enrich', { method: 'POST', body: fd });
+      const blob = await res.blob();
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'enriched.csv';
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+    };
+  </script>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+fastapi
+uvicorn[standard]
+pandas
+httpx
+python-multipart
+jinja2


### PR DESCRIPTION
## Summary
- add FastAPI service for property enrichment using Estated API
- add Tailwind-powered upload page
- document usage in README
- define project dependencies

## Testing
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6847e4f854908321b3c56c7cf494abda